### PR TITLE
Delete ReplicaSets by name

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -222,7 +222,7 @@ node_types:
             method: read_namespaced_replica_set
           delete:
             api: ExtensionsV1beta1Api
-            method: delete_collection_namespaced_replica_set
+            method: delete_namespaced_replica_set
             payload: V1DeleteOptions
 
   cloudify.kubernetes.resources.Service:


### PR DESCRIPTION
Use non-collection version of delete method for ReplicaSets since delete_resource
method implemented in client does not support additional parameters like
field_selector. In current approach ReplicaSets which are not a part of
current deployment can be deleted during uninstall operation.