### PR TITLE
Resolve problem with importing opentype

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     install_requires=[
         'cloudify-plugins-common>=3.3.1',
         'kubernetes==1.0.2',
-        'pyyaml'
+        'pyyaml',
+        'pyasn1-modules<0.2.1'
     ]
 )


### PR DESCRIPTION
pyasn1-modules in version 0.2.1 depends on pyasn1>=0.4.1 where opentype
is available. On cloudify manager 4.1.1 pyasn1 is installed in version
0.2.3. Since requirement for pyasn1>=0.4.1 does not install pyasn1 in
deployment's venv try to require older version of pyasn1-modules.

Closes #35